### PR TITLE
Multi-stage social distancing for NYC simulation

### DIFF
--- a/epiforecast/epidemic_simulator.py
+++ b/epiforecast/epidemic_simulator.py
@@ -81,6 +81,7 @@ class EpidemicSimulator:
                 step_time = self.time + step * self.static_contact_interval
                 interval_contact_duration = self.contact_simulator.mean_contact_duration(stop_time = step_time)
                 daily_contacts_cycle.append(interval_contact_duration)
+                print("%d/%d steps completed"%(step,len(daily_steps)))
 
             end = timer()
 

--- a/examples/super_simple_epidemic.py
+++ b/examples/super_simple_epidemic.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 
 # Utilities for generating random populations
 from epiforecast.populations import assign_ages, sample_distribution, TransitionRates
-from epiforecast.samplers import GammaSampler, AgeDependentBetaSampler
+from epiforecast.samplers import GammaSampler, AgeDependentBetaSampler, AgeDependentConstant
 
 from epiforecast.health_service import HealthService
 from epiforecast.contact_simulator import DiurnalContactInceptionRate
@@ -43,9 +43,9 @@ transition_rates = TransitionRates(population_network,
                   latent_periods = 3.7,
      community_infection_periods = 3.2,
       hospital_infection_periods = 5.0,
-        hospitalization_fraction = AgeDependentBetaSampler(mean=[0.002,  0.01,   0.04, 0.075,  0.16], b=4),
-    community_mortality_fraction = AgeDependentBetaSampler(mean=[ 1e-4,  1e-3,  0.003,  0.01,  0.02], b=4),
-     hospital_mortality_fraction = AgeDependentBetaSampler(mean=[0.019, 0.075,  0.195, 0.328, 0.514], b=4)
+        hospitalization_fraction = AgeDependentConstant([0.002,  0.01,   0.04, 0.075,  0.16]),
+    community_mortality_fraction = AgeDependentConstant([ 1e-4,  1e-3,  0.003,  0.01,  0.02]),
+     hospital_mortality_fraction = AgeDependentConstant([0.019, 0.075,  0.195, 0.328, 0.514])
 
 )
 


### PR DESCRIPTION
This PR modifies "simulate_idealized_NYC_epidemic.py" to use "EpidemicSimulator" for the NYC simulations.

There are a few changes in "simulate_idealized_NYC_epidemic.py":

* health service is being used now
* multi-stage distancing interventions can be modeled
* new latex-friendly plotting routines

First results on a 10,000 node network:

![new_york_cases](https://user-images.githubusercontent.com/2512712/83565609-8d115700-a4d3-11ea-8991-76a5e7441710.png)


