### PR TITLE
Use function closure `not_involving` rather than callable class `NotInvolving` for filtering patient-connected edges

### DIFF
--- a/epiforecast/epidemic_simulator.py
+++ b/epiforecast/epidemic_simulator.py
@@ -5,7 +5,7 @@ from timeit import default_timer as timer
 
 from .contact_simulator import ContactSimulator
 from .kinetic_model_simulator import KineticModel, print_statuses
-from .utilities import NotInvolving
+from .utilities import not_involving
 
 day = 1
 hour = day / 24
@@ -90,13 +90,13 @@ class EpidemicSimulator:
 
                 if len(admitted) > 0:
                     for patient in admitted:
-                        edges_to_remove.update(filter(NotInvolving(previous_patients), patient.community_contacts))
+                        edges_to_remove.update(filter(not_involving(previous_patients), patient.community_contacts))
                         edges_to_add.update(patient.health_worker_contacts)
 
                 if len(discharged) > 0:
                     for patient in discharged:
                         edges_to_remove.update(patient.health_worker_contacts)
-                        edges_to_add.update(filter(NotInvolving(current_patients), patient.community_contacts))
+                        edges_to_add.update(filter(not_involving(current_patients), patient.community_contacts))
 
             else:
                 edges_to_add, edges_to_remove = set(), set()

--- a/epiforecast/health_service.py
+++ b/epiforecast/health_service.py
@@ -3,7 +3,7 @@ import numpy as np
 import networkx as nx
 from functools import singledispatch
 
-from .utilities import normalize, NotInvolving
+from .utilities import normalize, not_involving
 
 @singledispatch
 def recruit_health_workers(workers, network):
@@ -156,7 +156,7 @@ class HealthService:
         self.patients = self.patients - discharged_patients
 
         # Filter contacts with current patients from the list of contacts to add to network
-        discharged_community_contacts = [edge for edge in filter(NotInvolving(self.current_patient_addresses()), discharged_community_contacts)]
+        discharged_community_contacts = [edge for edge in filter(not_involving(self.current_patient_addresses()), discharged_community_contacts)]
         population_network.add_edges_from(discharged_community_contacts)
 
         return discharged_patients

--- a/epiforecast/utilities.py
+++ b/epiforecast/utilities.py
@@ -13,15 +13,14 @@ def seed_three_random_states(seed):
     np.random.seed(seed)
     seed_numba_random_state(seed)
 
-class NotInvolving:
+def not_involving(nodes):
     """
     Filters edges that connect to `nodes`.
     """
-    def __init__(self, nodes):
-        self.nodes = nodes
+    def edge_doesnt_involve_any_nodes(edge, nodes=nodes):
+        return edge[0] not in nodes and edge[1] not in nodes
 
-    def __call__(self, edge):
-        return edge[0] not in self.nodes and edge[1] not in self.nodes
+    return edge_doesnt_involve_any_nodes
 
 @njit
 def normalize(edge):
@@ -32,5 +31,3 @@ def normalize(edge):
     if m > n: # switch
         n, m = m, n
     return n, m
-
-


### PR DESCRIPTION
It's slightly faster, according to python experts.