### PR TITLE
DataObservation requires contact_network

### DIFF
--- a/epiforecast/data_assimilator.py
+++ b/epiforecast/data_assimilator.py
@@ -87,6 +87,7 @@ class DataAssimilator:
 
     def find_observation_states(
             self,
+            user_network,
             ensemble_state,
             data):
         """
@@ -97,7 +98,7 @@ class DataAssimilator:
         print("Observation type : Number of Observed states")
         observed_states = []
         for observation in self.observations:
-            observation.find_observation_states(ensemble_state, data)
+            observation.find_observation_states(user_network, ensemble_state, data)
             print(observation.name,":",len(observation.obs_states))
             if observation.obs_states.size > 0:
                 observed_states.extend(observation.obs_states)
@@ -120,8 +121,7 @@ class DataAssimilator:
                 observation.observe(contact_network,
                                     state,
                                     data,
-                                    scale,
-                                    noisy_measurement)
+                                    scale)
 
                 observed_means.extend(observation.mean)
                 observed_variances.extend(observation.variance)
@@ -182,7 +182,7 @@ class DataAssimilator:
             om = self.observations
             dam = self.damethod
 
-            obs_states = self.find_observation_states(ensemble_state, data) # Generate states to observe
+            obs_states = self.find_observation_states(user_network, ensemble_state, data) # Generate states to observe
             if (obs_states.size > 0):
 
                 print("Total states to be assimilated: ", obs_states.size)

--- a/epiforecast/measurements.py
+++ b/epiforecast/measurements.py
@@ -146,6 +146,7 @@ class StateInformedObservation:
 
     def find_observation_states(
             self,
+            contact_network,
             state,
             data):
         """
@@ -201,16 +202,17 @@ class Observation(StateInformedObservation, TestMeasurement):
 
     def find_observation_states(
             self,
+            contact_network,
             state,
             data):
         """
         Obtain where one should make an observation based on the current state,
-        and the contact network
 
         Inputs:
             state: np.array of size [self.N * n_status]
         """
         StateInformedObservation.find_observation_states(self,
+                                                         contact_network,
                                                          state,
                                                          data)
 
@@ -265,6 +267,7 @@ class DataInformedObservation:
 
     def find_observation_states(
             self,
+            contact_network,
             state,
             data):
         """
@@ -322,6 +325,7 @@ class DataObservation(DataInformedObservation):
 
     def find_observation_states(
             self,
+            contact_network,
             state,
             data):
         """
@@ -332,6 +336,7 @@ class DataObservation(DataInformedObservation):
             state: np.array of size [self.N * n_status]
         """
         DataInformedObservation.find_observation_states(self,
+                                                        contact_network,
                                                         state,
                                                         data)
 
@@ -395,12 +400,14 @@ class DataNodeInformedObservation(DataInformedObservation):
 
     def find_observation_states(
             self,
+            contact_network,
             state,
             data):
         """
         Update the observation model when taking observation
         """
         DataInformedObservation.find_observation_states(self,
+                                                        contact_network,
                                                         state,
                                                         data)
         self.obs_nodes       = self.obs_states % self.N 
@@ -433,6 +440,7 @@ class DataNodeObservation(DataNodeInformedObservation, TestMeasurement):
 
     def find_observation_states(
             self,
+            contact_network,
             state,
             data):
         """
@@ -443,6 +451,7 @@ class DataNodeObservation(DataNodeInformedObservation, TestMeasurement):
             state: np.array of size [self.N * n_status]
         """
         DataNodeInformedObservation.find_observation_states(self,
+                                                            contact_network,
                                                             state,
                                                             data)
 


### PR DESCRIPTION
I hadn't tested the prior PR with DataInformedObservations just Observations, these require the contact_network so we cannot remove it. All I have done is undo this change. My apologies.