### PR TITLE
updated some codes of solvers for DA examples.

### DIFF
--- a/epiforecast/data_assimilator.py
+++ b/epiforecast/data_assimilator.py
@@ -335,10 +335,16 @@ class DataAssimilator:
 
             free_mass = np.sum(free_states,axis=1) + Emass[:,observed_nodes]
 
-            # normalize the free values e.g for S: set S = (1-I) * S/(S+E+H+R+D)
+            ## normalize the free values e.g for S: set S = (1-I) * S/(S+E+H+R+D)
+            #for i in free_statuses:
+            #    ensemble_state[:, i*N+observed_nodes] = (
+            #        (1.0 - updated_mass[:,0,:])*(free_states[:,i,:] / free_mass)
+            #            )
+
             for i in free_statuses:
-                ensemble_state[:, i*N+observed_nodes] = (
-                    (1.0 - updated_mass[:,0,:])*(free_states[:,i,:] / free_mass)
-                        )
-
-
+                #no_update_weight = (free_mass < 0.001)
+                no_update_weight = (free_mass == 0)
+                new_ensemble_state = (1.0 - updated_mass[:,0,:])\
+                                   * (free_states[:, i, :] / np.maximum(1e-9,free_mass))
+                ensemble_state[:, i*N+observed_nodes] = (no_update_weight) *  ensemble_state[:, i*N+observed_nodes]\
+                                                      + (1-no_update_weight) * new_ensemble_state

--- a/epiforecast/ensemble_adjustment_kalman_filter.py
+++ b/epiforecast/ensemble_adjustment_kalman_filter.py
@@ -93,7 +93,8 @@ class EnsembleAdjustmentKalmanFilter:
         # print(np.diag(cov)[:3])
         # print("----------------------------------------------------")
 
-        cov = (1./np.maximum(x_t, 1e-12)/np.maximum(1-x_t, 1e-12))**2 * cov
+        #cov = (1./np.maximum(x_t, 1e-12)/np.maximum(1-x_t, 1e-12))**2 * cov
+        cov = np.clip((1./np.maximum(x_t, 1e-12)/np.maximum(1-x_t, 1e-12)), -5, 5)**2 * cov
         x_t = np.log(np.maximum(x_t, 1e-12)/np.maximum(1.-x_t, 1e-12))
        
 

--- a/epiforecast/measurements.py
+++ b/epiforecast/measurements.py
@@ -184,9 +184,11 @@ class Observation(StateInformedObservation, TestMeasurement):
             max_threshold=1.0,
             sensitivity=0.80,
             specificity=0.99,
-            noisy_measurement=False):
+            noisy_measurement=False,
+            obs_var_min = 1e-3):
         
         self.name=obs_name
+        self.obs_var_min = obs_var_min
         
         StateInformedObservation.__init__(self,
                                           N,
@@ -243,7 +245,7 @@ class Observation(StateInformedObservation, TestMeasurement):
                                                       scale)
 
         observed_mean     = np.array([mean[node] for node in observed_nodes])
-        observed_variance = np.array([np.maximum(var[node], 1e-3) for node in observed_nodes])
+        observed_variance = np.array([np.maximum(var[node], self.obs_var_min) for node in observed_nodes])
 
         self.mean     = observed_mean
         self.variance = observed_variance

--- a/epiforecast/risk_simulator.py
+++ b/epiforecast/risk_simulator.py
@@ -121,6 +121,11 @@ class MasterEquationModelEnsemble:
         self.PM = np.identity(self.M) - 1./self.M * np.ones([self.M,self.M])
 
     #  Set methods -------------------------------------------------------------
+    def set_start_time(
+            self,
+            start_time):
+        self.start_time = start_time
+
     def set_mean_contact_duration(
             self,
             new_mean_contact_duration=None):


### PR DESCRIPTION
Several files in 'epiforecast' folder have been modified for setting up DA examples:
1. data_assimilator.py: resolved the issue of dividing zero when free_mass is zero;
2. ensemble_adjustment_kalman_filter.py: added a clipping to the scaling factor of covariance when using logit transform;
3. measurements.py: enabled users to define minimum observation noise;
4. risk_simulator.py: added a function to set start time for the master equation solver.