### PR TITLE
Inherit attributes & update user_network from contact_network

### DIFF
--- a/epiforecast/contact_network.py
+++ b/epiforecast/contact_network.py
@@ -676,7 +676,10 @@ class ContactNetwork:
             self,
             contact_network):
         """
-        Update the graph from another object
+        Update the graph from another object whose graph is a supergraph
+
+        The contact_network.graph should have at least the same nodes as
+        self.graph, plus maybe additional ones.
 
         Input:
             contact_network (ContactNetwork): object to update from


### PR DESCRIPTION
This PR deals with two issues:
1. when creating a `ContactNetwork` object via `from_networkx_graph` all attributes are now passed on; the syntax hasn't changed:
```python
network = ContactNetwork.from_networkx_graph(graph)
# with regards to user network creation:
user_network = network.build_user_network_using(SomeGraphBuilder())
```
2. when running a simulation for synthetic data, the user network should be updated accordingly; hence, a new method is implemented:
```python
for time in time_span:
    network = epidemic_simulator.run(network)
    user_network.update_from(network)
    # other stuff with user_network
```

The second feature hasn't been tested properly yet because there's currently no example in `master` that utilizes user networks. Once this is merged into `master` and then into `paper-examples`, we can test it.