### PR TITLE
added dictionaries to save observed states,means,variances by time

### DIFF
--- a/epiforecast/data_assimilator.py
+++ b/epiforecast/data_assimilator.py
@@ -188,7 +188,6 @@ class DataAssimilator:
             ...
             verbose (bool): whether to print info about each observation
         """
-        print(self.stored_observed_states)
         ensemble_size = ensemble_state.shape[0]
 
         if len(self.observations) == 0: # no update is performed; return input


### PR DESCRIPTION
This prevents finding and measuring observed states in the past when performing backward-forward DA.
simply stores the observed states, the means and variances as dicts:
`{ time : np.array}`