### PR TITLE
Fix ray memory & temp_dir issues

### DIFF
--- a/examples/da-sandbox/_argparse_init.py
+++ b/examples/da-sandbox/_argparse_init.py
@@ -13,6 +13,8 @@ print_info_module(__name__, "parsing args of PID:", os.getpid())
 # parallel #####################################################################
 parser.add_argument('--parallel-flag', default=False, action='store_true')
 parser.add_argument('--parallel-num-cpus', type=int, default=1)
+parser.add_argument('--parallel-memory', type=int, default=4_000_000_000) # 4GB
+parser.add_argument('--parallel-temp-dir', type=str, default='')
 
 # constants ####################################################################
 parser.add_argument('--constants-output-path', type=str, default='')

--- a/examples/da-sandbox/_general_init.py
+++ b/examples/da-sandbox/_general_init.py
@@ -13,9 +13,18 @@ print_start_of(__name__)
 ################################################################################
 # parallel #####################################################################
 if arguments.parallel_flag:
+    object_store_memory = min(arguments.parallel_memory // 2, 2_000_000_000)
+    memory = arguments.parallel_memory - object_store_memory
+
+    if len(arguments.parallel_temp_dir) > 0:
+        temp_dir = arguments.parallel_temp_dir
+    else:
+        temp_dir = None # this is the default in ray's method
+
     ray.init(num_cpus=arguments.parallel_num_cpus,
-             #memory=2_000_000_000,
-             #object_store_memory=2_000_000_000
+             memory=memory,
+             object_store_memory=object_store_memory,
+             temp_dir=temp_dir
     )
 
 # numba ########################################################################


### PR DESCRIPTION
This PR fixes the two small issues that arise on cluster when running in parallel mode.

There are two new arguments:
 - `--parallel-memory` which controls the total amount of memory allowed for `ray` (4Gb by default)
 - `--parallel-temp-dir` which sets the temporary directory for `ray` to use (defaults to `None`, which further defaults to `/usr/tmp/` by `ray` itself I believe)

I lost track who uses which slurm scripts, so haven't updated any, but nudge me if you want something specific changed. I'd say a typical usage would be:
```bash
memory=$(( SLURM_MEM_PER_NODE} / 4 )) # or simply memory=4000000000
temp_dir="/central/home/your_name/temp_dir"
mkdir -p "${temp_dir}"

srun python3 backward_forward_assimilation.py \
  # other stuff
  --parallel-memory=${memory} \
  --parallel-temp-dir=${temp_dir}
```

But this should at least solve the memory issue out of the box; the `temp_dir` thing, if persists, set it manually.